### PR TITLE
fix(validation): Support qualified keys for required arguments

### DIFF
--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -76,11 +76,34 @@ class DisqusResource {
             throw new DisqusInterfaceNotDefined();
         }
         $kwargs = (array)$args[0];
+        $missing_required = [];
 
-        foreach ((array)$resource->required as $k) {
-            if (empty($kwargs[$k])) {
-                throw new Exception('Missing required argument: '.$k);
+        foreach ((array)$resource->required as $k) { 
+            
+            $found_and_not_empty = false;
+
+            foreach ($kwargs as $key => $value) { 
+                
+                if (str_starts_with($key, $k)) {
+                    
+                    $suffix = substr($key, strlen($k));
+                    
+                    if ($suffix === '' || str_starts_with($suffix, ':')) {
+                        if (!empty($value)) {
+                            $found_and_not_empty = true;
+                            break; 
+                        }
+                    }
+                }
             }
+
+            if (!$found_and_not_empty) {
+                $missing_required[] = $k;
+            }
+        }
+
+        if (!empty($missing_required)) {
+            throw new Exception('Missing required argument(s): ' . implode(', ', $missing_required));
         }
 
         $api = $this->api;


### PR DESCRIPTION
### 🐛 What was the problem?

The previous argument validation logic checked for required parameters using a direct, exact key match. For example, if a resource required the `thread` argument, the code would check for `empty($kwargs['thread'])`.

This check incorrectly failed if the argument was provided with a qualified identifier (e.g., `thread:ident`), as the key thread would not be found. This caused the system to throw a `Missing required argument: thread` exception, even when the requirement was logically satisfied.

### 💡 What is the fix?

This PR changes the validation logic to correctly handle qualified keys.

Instead of an exact key lookup, the new logic now:

1. Iterates through all required argument keys (e.g., $k = `'thread'`).

2. For each required key, it iterates through all provided argument keys (e.g., `$key = 'thread:ident'`).

3. It uses a prefix check `(str_starts_with())` to find any provided key that starts with the required key.

4. It validates the match by ensuring the suffix is either empty (for an exact match) or begins with a colon (:). This prevents a required key like arg from incorrectly matching argument.

5. Once a valid key is found, it applies the !empty() check to that key's value, ensuring a non-empty value was provided.

This change ensures that arguments like `thread:ident` are correctly recognized as satisfying the requirement for thread.